### PR TITLE
SMS Twilio API Key

### DIFF
--- a/API/Controllers/SMSController.cs
+++ b/API/Controllers/SMSController.cs
@@ -14,9 +14,11 @@ namespace API.Controllers
         public async Task<ActionResult<string>> SendOrderCompleteSMS(string phoneNumber, string orderNumber)
         {
             string accountSid = Configuration["twillosettings:accountSid"];
-            string authToken = Configuration["twillosettings:authToken"];// Do not put this in git hub at all, right now its in the gitignore keep it there
 
-            TwilioClient.Init(accountSid, authToken);
+            string apiKeySid = Configuration["twillosettings:apiKeySid"];
+            string apiKeySecret = Configuration["twillosettings:apiKeySecret"];// Do not put this in git hub at all, right now its in the gitignore keep it there
+
+            TwilioClient.Init(apiKeySid, apiKeySecret, accountSid);
 
             string msgBody = "Rodizio Express. Your order #" + orderNumber + " is ready! Go to the till to collect.\n Thank you for your purchase.\n Powered by Pixel Pro";
 
@@ -33,10 +35,12 @@ namespace API.Controllers
         public async Task<ActionResult<string>> SendOrderCancelSMS(string phoneNumber, string orderNumber)
         {
             //From rodizio express api key
-            string accountSid = "SK4dfe74260f4947fc4be3c85fe774c21a";
-            string authToken = "IR0mVNFst7gx7f8vQMebM9pGwyx2DJ2l";
+            string accountSid = Configuration["twillosettings:accountSid"];
 
-            TwilioClient.Init(accountSid, authToken);
+            string apiKeySid = Configuration["twillosettings:apiKeySid"];
+            string apiKeySecret = Configuration["twillosettings:apiKeySecret"];// Do not put this in git hub at all, right now its in the gitignore keep it there
+
+            TwilioClient.Init(apiKeySid, apiKeySecret, accountSid);
 
             string msgBody = "Rodizio Express. Your order #" + orderNumber + " has been cancelled. Powered by Pixel Pro";
 
@@ -54,9 +58,11 @@ namespace API.Controllers
         public async Task<ActionResult<string>> SendResetPasswordSMS(string phoneNumber, string temporarypasswordtoken)
         {
             string accountSid = Configuration["twillosettings:accountSid"];
-            string authToken = Configuration["twillosettings:authToken"];// Do not put this in git hub at all, right now its in the gitignore keep it there
 
-            TwilioClient.Init(accountSid, authToken);
+            string apiKeySid = Configuration["twillosettings:apiKeySid"];
+            string apiKeySecret = Configuration["twillosettings:apiKeySecret"];// Do not put this in git hub at all, right now its in the gitignore keep it there
+
+            TwilioClient.Init(apiKeySid, apiKeySecret, accountSid);
 
             string msgBody = $"Rodizio Express. Please click this {temporarypasswordtoken} link to get your temporary password token. Please change your password withing 2 hours.\n Powered by Pixel Pro";
 

--- a/API/appsettings.json
+++ b/API/appsettings.json
@@ -17,7 +17,8 @@
   },
   "twillosettings": {
     "accountSid": "ACb6bff2fe1dd75e7f0ef7ec2c0d4d7b84",
-    "authToken": "71c2b37eb6e48f1eb985e0bce05861f0" //Do not, under any circumstances, make this file allowed to be shared in github. To many secrets are here
+    "apiKeySid": "SK9eadff7b635ab641ada07c8a1536a0e1", //I'm using an api key instead of auth token since that changes from time to time
+    "apiKeySecret": "hEKnhiednjvHd1zCNi9SC2Xe6bY4OtGb" //Do not, under any circumstances, make this file allowed to be shared in github. To many secrets are here
   },
   "EmailConfiguration": {
     //I don't think a smtp server account exists so don't expect it to work


### PR DESCRIPTION
Switched from using accountSid and authToken for logging into the twilio client. Were now using an api key.

Switched because auth token rotate randomly and cause the sms system to stop working randomly.

appsettings.json has new keys and values under twiliosettings.